### PR TITLE
Bump aio-libs/get-releasenote to v1.2.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
   steps:
   - name: Prepare Release Note
     id: note
-    uses: aio-libs/get-releasenote@v1.2.1
+    uses: aio-libs/get-releasenote@v1.2.2
     with:
       changes_file: ${{ inputs.changes_file }}
       output_file: release_note.md


### PR DESCRIPTION
Also needs a git tag (v1.3.3).